### PR TITLE
Use the correct application id variable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,7 @@ var languageStrings = {
 
 exports.handler = function(event, context, callback) {
     var alexa = Alexa.handler(event, context);
-    alexa.APP_ID = APP_ID;
+    alexa.appId = APP_ID;
     // To enable string internationalization (i18n) features, set a resources object.
     alexa.resources = languageStrings;
     alexa.registerHandlers(handlers);


### PR DESCRIPTION
The correct application id must be set to `appId` and not `APP_ID` otherwise the lambda functions reports that the id is not set.

This is also reported in the developer forum https://forums.developer.amazon.com/questions/36825/how-to-fix-warning-application-id-is-not-set.html