### PR TITLE
Fix broken link

### DIFF
--- a/step-by-step/2-lambda-function.md
+++ b/step-by-step/2-lambda-function.md
@@ -37,7 +37,7 @@ In the [first step of this guide](https://github.com/alexa/skill-sample-nodejs-f
 
 8.  **Paste the provided code into the Lambda function code box.**  We have provided the code for this skill on [GitHub](https://github.com/alexa/skill-sample-nodejs-fact/blob/master/src/index.js).  Simply delete the contents of the code box, and paste the contents of the new code.
 
-9.  **Set up your Lambda function role.**  If you haven't done this before, we have a [detailed walkthrough for setting up your first role for Lambda](LAMBDAROLE.md).  If you have done this before, you only need to set your **Existing role** value to "lambda_basic_execution."
+9.  **Set up your Lambda function role.**  If you haven't done this before, we have a [detailed walkthrough for setting up your first role for Lambda](../lambda-role.md).  If you have done this before, you only need to set your **Existing role** value to "lambda_basic_execution."
 
     <img src="https://m.media-amazon.com/images/G/01/mobile-apps/dex/alexa/alexa-skills-kit/tutorials/general/2-9-lambda-function-role._TTH_.png" />
 


### PR DESCRIPTION
Fix the broken link in step 9  ("detailed walk-through for setting up your first role for Lambda")
NB: now points to ../lambda-role.md - that page has broken image links.