### PR TITLE
fix set-up-aws link

### DIFF
--- a/set-up-aws.md
+++ b/set-up-aws.md
@@ -2,7 +2,7 @@
  
   **Note: If you already have an AWS account, you can skip this section.  Just sign in to your [console](http://aws.amazon.com).**
 
-1.  Open [aws.amazon.com](aws.amazon.com) and then choose **‘Create an AWS Account’**
+1.  Open [aws.amazon.com](https://aws.amazon.com) and then choose **‘Create an AWS Account’**
 
     <img src="https://m.media-amazon.com/images/G/01/mobile-apps/dex/alexa/alexa-skills-kit/tutorials/general/buttons/create-an-aws-account-button._TTH_.png" />
 


### PR DESCRIPTION
the old link (aws.amazon.com) results in a Github 404