### PR TITLE
Fixed alexa.appId property

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ var data = [
 //=========================================================================================================================================
 exports.handler = function(event, context, callback) {
     var alexa = Alexa.handler(event, context);
-    alexa.APP_ID = APP_ID;
+    alexa.appID = APP_ID;
     alexa.registerHandlers(handlers);
     alexa.execute();
 };


### PR DESCRIPTION
alexa.APP_ID doesn't work, causing "Application ID not set" warnings. The correct property is appID.