### PR TITLE
Upgraded Nodejs skill templates from v8 to v10

### DIFF
--- a/ask-resources.json
+++ b/ask-resources.json
@@ -23,7 +23,7 @@
         },
         "skillInfrastructure": {
           "userConfig": {
-            "runtime": "nodejs8.10",
+            "runtime": "nodejs10.x",
             "handler": "index.handler"
           }
         }


### PR DESCRIPTION

Since the Node.js 8.10 will soon be EOL, ASK SDK team upgraded the Node skill templates to Node.js 10.x 