### PR TITLE
Fix portuguese word

### DIFF
--- a/lambda/custom/index.js
+++ b/lambda/custom/index.js
@@ -407,7 +407,7 @@ const ptData = {
   translation: {
     SKILL_NAME: 'Fatos Espaciais',
     GET_FACT_MESSAGE: 'Aqui vai: ',
-    HELP_MESSAGE: 'Você pode me perguntar por um fato interessante sobre o espaço, ou, fexar a skill. Como posso ajudar?',
+    HELP_MESSAGE: 'Você pode me perguntar por um fato interessante sobre o espaço, ou, fechar a skill. Como posso ajudar?',
     HELP_REPROMPT: 'O que vai ser?',
     FALLBACK_MESSAGE: 'A skill fatos espaciais não tem uma resposta para isso. Ela pode contar informações interessantes sobre o espaço, é só perguntar. Como posso ajudar?',
     FALLBACK_REPROMPT: 'Eu posso contar fatos sobre o espaço. Como posso ajudar?',


### PR DESCRIPTION
*Description of changes:*
Fixed wrong word in brazilian portuguese. "Fexar" to "Fechar".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
